### PR TITLE
Add manage_home to remove action of manage resource.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the users cookbook.
 
 ## Unreleased
 
+- Add manage_home to the remove action of the manage resource
+
 ## 5.6.0 - *2021-01-31*
 
 - Sous Chefs Adoption

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ A sample user to remove from a system would like like:
 Other potential fields (optional):
 
 - `home`: _String_ User's home directory. If not assigned, will be set based on platform and username.
+- `manage_home`: _True, False_ Creates/removes the home directory. Defaults to false. 
 - `action`: _String_ Supported actions are one's supported by the [user](https://docs.chef.io/resource_user.html#actions) resource. If not specified, the default action is `create`.
 - `ssh_private_key`: _String_ manages user's private key generally ~/.ssh/id_*
 - `ssh_public_key`: _String_ manages user's public key generally ~/.ssh/id_*.pub

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ A sample user to remove from a system would like like:
 Other potential fields (optional):
 
 - `home`: _String_ User's home directory. If not assigned, will be set based on platform and username.
-- `manage_home`: _True, False_ Creates/removes the home directory. Defaults to false. 
+- `manage_home`: _True, False_ Creates/removes the home directory. Defaults to false.
 - `action`: _String_ Supported actions are one's supported by the [user](https://docs.chef.io/resource_user.html#actions) resource. If not specified, the default action is `create`.
 - `ssh_private_key`: _String_ manages user's private key generally ~/.ssh/id_*
 - `ssh_public_key`: _String_ manages user's public key generally ~/.ssh/id_*.pub

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -164,6 +164,7 @@ action :remove do
   search(new_resource.data_bag, "groups:#{new_resource.search_group} AND action:remove") do |rm_user|
     user rm_user['username'] ||= rm_user['id'] do
       action :remove
+      manage_home rm_user['manage_home'] ||= false
       force rm_user['force'] ||= false
     end
   end


### PR DESCRIPTION
# Description

If manage_home is set to true, the users home directory will be created/removed based on the action of the manage resource.

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
