### PR TITLE
Fix uid validation multiple places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the users cookbook.
 
 ## Unreleased
 
+- Fix invalid checking of user[:uid] which could lead to root owning the users folders and files. Thanks @evandam
+
 ## 6.0.0 - *2021-03-12*
 
 - Removed hard dependency on data bags. See upgrading.md for details

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -96,7 +96,7 @@ action :create do
 
       directory "#{home_dir}/.ssh" do
         recursive true
-        owner user[:uid].to_i || username
+        owner user[:uid] ? user[:uid].to_i : username
         group user[:gid].to_i if user[:gid]
         mode '0700'
         not_if { user[:ssh_keys].nil? && user[:ssh_private_key].nil? && user[:ssh_public_key].nil? }
@@ -119,7 +119,7 @@ action :create do
       template key_file do
         source 'authorized_keys.erb'
         cookbook new_resource.cookbook
-        owner user[:uid].to_i || username
+        owner user['uid'] ? user[:uid].to_i : username
         group user[:gid].to_i if user[:gid]
         mode '0600'
         sensitive true
@@ -146,7 +146,7 @@ action :create do
         template "#{home_dir}/.ssh/id_#{key_type}" do
           source 'private_key.erb'
           cookbook new_resource.cookbook
-          owner user[:uid].to_i || username
+          owner user[:uid] ? user[:uid].to_i : username
           group user[:gid].to_i if user[:gid]
           mode '0400'
           variables private_key: user[:ssh_private_key]

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -119,7 +119,7 @@ action :create do
       template key_file do
         source 'authorized_keys.erb'
         cookbook new_resource.cookbook
-        owner user['uid'] ? user[:uid].to_i : username
+        owner user[:uid] ? user[:uid].to_i : username
         group user[:gid].to_i if user[:gid]
         mode '0600'
         sensitive true

--- a/test/fixtures/cookbooks/users_test/attributes/default.rb
+++ b/test/fixtures/cookbooks/users_test/attributes/default.rb
@@ -36,4 +36,12 @@ default['users_test']['users'] = [{
   'id': 'user_with_local_home',
   'groups': ['nfsgroup'],
   'ssh_private_key': "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\nQyNTUxOQAAACAummQxfsdvMSJWUoMn8odyAJHp3C6dVQlOyVwYSXFzcgAAAJjzcJxA83Cc\nQAAAAAtzc2gtZWQyNTUxOQAAACAummQxfsdvMSJWUoMn8odyAJHp3C6dVQlOyVwYSXFzcg\nAAAEC7TGfA0MU0mh0V39qw5RSThUo0idTtU2vCe9bJrHmyFS6aZDF+x28xIlZSgyfyh3IA\nkencLp1VCU7JXBhJcXNyAAAAFWZtdWxsZXJAc2JwbHRjMW1sbHZkbA==\n-----END OPENSSH PRIVATE KEY-----\n",
-}]
+},
+{
+  'username': 'user_with_username_instead_of_id',
+  'groups': ['nfsgroup'],
+  'shell': '/bin/bash',
+  'ssh_keys': ['ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC6aZDF+x28xIlZSgyfyh3IAkencLp1VCU7JXBhJcXNy cheftestuser@laptop'],
+  'ssh_private_key': "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\nQyNTUxOQAAACAummQxfsdvMSJWUoMn8odyAJHp3C6dVQlOyVwYSXFzcgAAAJjzcJxA83Cc\nQAAAAAtzc2gtZWQyNTUxOQAAACAummQxfsdvMSJWUoMn8odyAJHp3C6dVQlOyVwYSXFzcg\nAAAEC7TGfA0MU0mh0V39qw5RSThUo0idTtU2vCe9bJrHmyFS6aZDF+x28xIlZSgyfyh3IA\nkencLp1VCU7JXBhJcXNyAAAAFWZtdWxsZXJAc2JwbHRjMW1sbHZkbA==\n-----END OPENSSH PRIVATE KEY-----\n",
+  'ssh_public_key': 'ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCezwRzemhAGbqvvO/9RmiO9eOtRlUHn1HgvM4HDxxL/bFJCtUfyqbZfyQHXLqe7LJ0rRttAXWmcRLU/668bp70=',
+  }]

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -62,11 +62,15 @@ describe user('user_with_nfs_home_second') do
 end
 
 describe file('/home/user_with_nfs_home_second/.ssh/id_ecdsa') do
+  it { should exist }
   its('content') { should include("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS\n1zaGEyLW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQQns8Ec3poQBm6r7zv/UZojvXjrUZVB\n59R4LzOBw8cS/2xSQrVH8qm2X8kB1y6nuyydK0bbQF1pnES1P+uvG6e9AAAAsD2Nf449jX\n+OAAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCezwRzemhAGbqvv\nO/9RmiO9eOtRlUHn1HgvM4HDxxL/bFJCtUfyqbZfyQHXLqe7LJ0rRttAXWmcRLU/668bp7\n0AAAAgJp/B6o2OADM0+NlkgH1dFcOLK64jhr3ScbWK4iyRdOcAAAAVZm11bGxlckBzYnBs\ndGMxbWxsdmRsAQID\n-----END OPENSSH PRIVATE KEY-----\n") }
+  its('owner') { should eq 'user_with_nfs_home_second' }
 end unless os_family == 'darwin' # InSpec runs as non-root and can't see these files
 
 describe file('/home/user_with_nfs_home_second/.ssh/id_ecdsa.pub') do
+  it { should exist }
   its('content') { should include('ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCezwRzemhAGbqvvO/9RmiO9eOtRlUHn1HgvM4HDxxL/bFJCtUfyqbZfyQHXLqe7LJ0rRttAXWmcRLU/668bp70=') }
+  its('owner') { should eq 'user_with_nfs_home_second' }
 end unless os_family == 'darwin' # InSpec runs as non-root and can't see these files
 
 describe user('user_with_local_home') do
@@ -84,11 +88,54 @@ end
 
 describe directory('/home/user_with_local_home') do
   it { should exist }
+  its('owner') { should eq 'user_with_local_home' }
 end unless os_family == 'darwin' # InSpec runs as non-root and can't see these files
 
 describe file('/home/user_with_local_home/.ssh/id_rsa') do
+  it { should exist }
   its('content') { should include("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\nQyNTUxOQAAACAummQxfsdvMSJWUoMn8odyAJHp3C6dVQlOyVwYSXFzcgAAAJjzcJxA83Cc\nQAAAAAtzc2gtZWQyNTUxOQAAACAummQxfsdvMSJWUoMn8odyAJHp3C6dVQlOyVwYSXFzcg\nAAAEC7TGfA0MU0mh0V39qw5RSThUo0idTtU2vCe9bJrHmyFS6aZDF+x28xIlZSgyfyh3IA\nkencLp1VCU7JXBhJcXNyAAAAFWZtdWxsZXJAc2JwbHRjMW1sbHZkbA==\n-----END OPENSSH PRIVATE KEY-----\n") }
 end unless os_family == 'darwin' # InSpec runs as non-root and can't see these files
+
+describe user('user_with_username_instead_of_id') do
+  it { should exist }
+  case os_family
+  when 'suse'
+    its('groups') { should eq %w( users nfsgroup ) }
+  when 'darwin'
+    its('groups') { should include 'nfsgroup' }
+  else
+    its('groups') { should eq %w( user_with_username_instead_of_id nfsgroup ) }
+  end
+  its('shell') { should eq '/bin/bash' }
+end
+
+describe directory('/home/user_with_username_instead_of_id') do
+  it { should exist }
+  its('owner') { should eq 'user_with_username_instead_of_id' }
+end unless os_family == 'darwin'
+
+describe directory('/home/user_with_username_instead_of_id/.ssh') do
+  it { should exist }
+  its('owner') { should eq 'user_with_username_instead_of_id' }
+end unless os_family == 'darwin'
+
+describe file('/home/user_with_username_instead_of_id/.ssh/authorized_keys') do
+  it { should exist }
+  its('owner') { should eq 'user_with_username_instead_of_id' }
+  its('content') { should include('ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC6aZDF+x28xIlZSgyfyh3IAkencLp1VCU7JXBhJcXNy cheftestuser@laptop') }
+end unless os_family == 'darwin'
+
+describe file('/home/user_with_username_instead_of_id/.ssh/id_ecdsa') do
+  it { should exist }
+  its('owner') { should eq 'user_with_username_instead_of_id' }
+  its('content') { should include("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\nQyNTUxOQAAACAummQxfsdvMSJWUoMn8odyAJHp3C6dVQlOyVwYSXFzcgAAAJjzcJxA83Cc\nQAAAAAtzc2gtZWQyNTUxOQAAACAummQxfsdvMSJWUoMn8odyAJHp3C6dVQlOyVwYSXFzcg\nAAAEC7TGfA0MU0mh0V39qw5RSThUo0idTtU2vCe9bJrHmyFS6aZDF+x28xIlZSgyfyh3IA\nkencLp1VCU7JXBhJcXNyAAAAFWZtdWxsZXJAc2JwbHRjMW1sbHZkbA==\n-----END OPENSSH PRIVATE KEY-----\n") }
+end unless os_family == 'darwin'
+
+describe file('/home/user_with_username_instead_of_id/.ssh/id_ecdsa.pub') do
+  it { should exist }
+  its('owner') { should eq 'user_with_username_instead_of_id' }
+  its('content') { should include('ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCezwRzemhAGbqvvO/9RmiO9eOtRlUHn1HgvM4HDxxL/bFJCtUfyqbZfyQHXLqe7LJ0rRttAXWmcRLU/668bp70=') }
+end unless os_family == 'darwin'
 
 # Test users from databags
 describe user('databag_mwaddams') do
@@ -141,5 +188,6 @@ ssh_keys = [
 describe file('/home/databag_test_user_keys_from_url/.ssh/authorized_keys') do
   ssh_keys.each do |key|
     its('content') { should include(key) }
+    its('owner') { should eq 'databag_test_user_keys_from_url' }
   end
 end unless os_family == 'darwin' # InSpec runs as non-root and can't see these files


### PR DESCRIPTION
# Description

As described in #446  and #447  a breaking change was introduced in version 6.0.0:

```When creating a user without specifying a uid/gid, the user's ~/.ssh directory is owned by root since user[:uid].to_i returns 0 (since nil.to_i is 0) in https://github.com/sous-chefs/users/blob/master/resources/manage.rb#L99-L100.```

Although a separate pull request was already opened, there were more places where the same issue existed and that was not covered in that pull request.

I also added integration tests that prevent his bug from reappearing in the future.

Thanks @evandam for spotting it :)

## Issues Resolved

#446 
#447 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
