### PR TITLE
Failing test for user/group name match regression in v6

### DIFF
--- a/test/fixtures/cookbooks/users_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/users_test/recipes/default.rb
@@ -27,3 +27,9 @@ users_manage 'emptygroup' do
   group_id 5000
   action [:remove, :create]
 end
+
+# Creates a group where a user's name matches the group's name
+singleuser = [{ username: 'singleuser', groups: ['singleuser'] }]
+users_manage 'singleuser' do
+  users singleuser
+end


### PR DESCRIPTION
# Description

Prior to v6, you could use the `users_manage` resource for a group with a single user whose username matched the group name. For example:

```ruby
# databag
{
  id: 'deploy', 
  groups: ['deploy']
}

# recipe
users_manage 'deploy' do
  action :create
end
```

Starting with v6 (after resolving the upgrade steps due breaking the explicit dependency on data bags), the same steps now fail with an error like:
```
useradd: group deploy exists - if you want to add this user to that group, use -g.
```

I believe this is happening because in v6, the group is now created proactively:
https://github.com/sous-chefs/users/blob/afecffa5f2d8e00148bff9022368241912904d9f/resources/manage.rb#L38-L46

Versus reactively in v5.7:
https://github.com/sous-chefs/users/blob/5.7.0/resources/manage.rb#L153-L160

I realize this may be an odd use for the resource since we're managing a single user rather than a group of users, however the URL-to-SSH keys feature is a nice touch, plus it worked before.

I'm not sure what direction the resolution should go in. Should this be an explicitly unsupported scenario? Does the initial creation of the group now need to be conditional, deferring it to after user creation when the user/group names match?

I originally hit this with Ubuntu 20.04, but CI confirms it's more than just an Ubuntu problem, affecting Amazon Linux, CentOS and Debian as well.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
