### PR TITLE
Allow a user to be in a group of the same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the users cookbook.
 
 ## Unreleased
 
+- Allows a given user to be in a group of the same name, that is already created or explicitly defined in its `groups` key
+
 ## 7.0.0 - *2021-06-21*
 
 - Set unified_mode to `true` for the `users_manage` resource

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -73,17 +73,5 @@ module Users
     def pubkey_type(pubkey)
       %w(ed25519 ecdsa dss rsa dsa).filter { |kt| pubkey.split.first.include?(kt) }.first || 'rsa'
     end
-
-    # Returns a group for a new user to be added to
-    #
-    # @return [String, Integer]
-    def user_gid(user)
-      username = user[:username] || user[:id]
-      if user[:gid]
-        user[:gid].to_i
-      elsif user[:groups].include?(username)
-        username
-      end
-    end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -73,5 +73,17 @@ module Users
     def pubkey_type(pubkey)
       %w(ed25519 ecdsa dss rsa dsa).filter { |kt| pubkey.split.first.include?(kt) }.first || 'rsa'
     end
+
+    # Returns a group for a new user to be added to
+    #
+    # @return [String, Integer]
+    def user_gid(user)
+      username = user[:username] || user[:id]
+      if user[:gid]
+        user[:gid].to_i
+      elsif user[:groups].include?(username)
+        username
+      end
+    end
   end
 end

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -78,15 +78,16 @@ action :create do
         gid user[:gid].to_i unless gid_used?(user[:gid].to_i) || new_resource.group_name == username
       else
         gid user[:gid].to_i
-      end
-      only_if { user[:gid] && user[:gid].is_a?(Numeric) && username_group }
+      end if user[:gid] && user[:gid].is_a?(Numeric)
+      only_if { user[:gid] && user[:gid].is_a?(Numeric) && username_group || user[:groups].include?(username) }
+      append true
     end
 
     # Create user object.
     # Do NOT try to manage null home directories.
     user username do
       uid user[:uid].to_i unless platform_family?('mac_os_x') || !user[:uid]
-      gid user[:gid].to_i if user[:gid]
+      gid user_gid(user) if user[:gid] || user[:groups].include?(username)
       shell shell_is_valid?(user[:shell]) ? user[:shell] : '/bin/sh'
       comment user[:comment]
       password user[:password] if user[:password]

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -87,7 +87,7 @@ action :create do
     # Do NOT try to manage null home directories.
     user username do
       uid user[:uid].to_i unless platform_family?('mac_os_x') || !user[:uid]
-      gid user_gid(user) if user[:gid] || user[:groups].include?(username)
+      gid user[:gid] || username if user[:gid] || user[:groups].include?(username)
       shell shell_is_valid?(user[:shell]) ? user[:shell] : '/bin/sh'
       comment user[:comment]
       password user[:password] if user[:password]

--- a/test/fixtures/cookbooks/users_test/attributes/default.rb
+++ b/test/fixtures/cookbooks/users_test/attributes/default.rb
@@ -44,4 +44,8 @@ default['users_test']['users'] = [{
   'ssh_keys': ['ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC6aZDF+x28xIlZSgyfyh3IAkencLp1VCU7JXBhJcXNy cheftestuser@laptop'],
   'ssh_private_key': "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\nQyNTUxOQAAACAummQxfsdvMSJWUoMn8odyAJHp3C6dVQlOyVwYSXFzcgAAAJjzcJxA83Cc\nQAAAAAtzc2gtZWQyNTUxOQAAACAummQxfsdvMSJWUoMn8odyAJHp3C6dVQlOyVwYSXFzcg\nAAAEC7TGfA0MU0mh0V39qw5RSThUo0idTtU2vCe9bJrHmyFS6aZDF+x28xIlZSgyfyh3IA\nkencLp1VCU7JXBhJcXNyAAAAFWZtdWxsZXJAc2JwbHRjMW1sbHZkbA==\n-----END OPENSSH PRIVATE KEY-----\n",
   'ssh_public_key': 'ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCezwRzemhAGbqvvO/9RmiO9eOtRlUHn1HgvM4HDxxL/bFJCtUfyqbZfyQHXLqe7LJ0rRttAXWmcRLU/668bp70=',
-  }]
+},
+{
+  'username': 'explicituser',
+  'groups': ['explicituser'],
+}]

--- a/test/fixtures/cookbooks/users_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/users_test/recipes/default.rb
@@ -27,3 +27,7 @@ users_manage 'emptygroup' do
   group_id 5000
   action [:remove, :create]
 end
+
+users_manage 'explicituser' do
+  users node['users_test']['users']
+end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -21,6 +21,10 @@ describe group('emptygroup') do
   end
 end
 
+describe group('explicituser') do
+  it { should exist }
+end
+
 # Test users from attributes
 describe user('usertoremove') do
   it { should_not exist }
@@ -94,6 +98,16 @@ describe user('user_with_local_home') do
     its('groups') { should eq %w( user_with_local_home nfsgroup ) }
   end
   its('shell') { should eq '/bin/sh' }
+end
+
+describe user('explicituser') do
+  it { should exist }
+  case os_family
+  when 'darwin'
+    its('groups') { should include 'explicituser' }
+  else
+    its('groups') { should eq %w( explicituser ) }
+  end
 end
 
 describe directory('/home/user_with_local_home') do


### PR DESCRIPTION
# Description

Allows a given user to be in a group of the same name, that is already created or explicitly defined in its 'groups' key.

Additionally fixes an issue with a test expecting nil but finding ""

## Issues Resolved

https://github.com/sous-chefs/users/pull/452

## Check List

- [X] All tests pass. See TESTING.md for details.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
