### PR TITLE
User owns their homedir group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of the users cookbook.
 
 ## Unreleased
 
+- Give group ownership of each users .ssh/* files to that users primary group
+- Allow user to set file permisions for their home directory
+- Add a 'primary_group' and 'homedir_mode' key to the user hash options
+
 ## 7.0.1 - *2021-07-02*
 
 - Allows a given user to be in a group of the same name, that is already created or explicitly defined in its `groups` key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ This file is used to list changes made in each version of the users cookbook.
 ## Unreleased
 
 - Give group ownership of each users .ssh/* files to that users primary group
-- Allow user to set file permisions for their home directory
-- Add a 'primary_group' and 'homedir_mode' key to the user hash options
+- Allow user to set file permissions for their home directory
+- Add a `primary_group` and `homedir_mode` key to the user hash options
 
 ## 7.0.1 - *2021-07-02*
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Other potential fields (optional):
 - `authorized_keys_file`: _String_ a nonstandard location for the authorized_keys file
 - `gid`: _String, Integer_ Specefies the primary group of a user by the gid number or the group name. The group will be created if it doesn't exist.
 - `primary_group`: _String_ To be used in combination with the `gid` field when the `gid` is an integer. Specifying the group name prevents errors when the user is created before their primary group.
+
 ## Resources Overview
 
 ### users_manage

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Other potential fields (optional):
 - `ssh_private_key`: _String_ manages user's private key generally ~/.ssh/id_*
 - `ssh_public_key`: _String_ manages user's public key generally ~/.ssh/id_*.pub
 - `authorized_keys_file`: _String_ a nonstandard location for the authorized_keys file
-- `gid`: _String, Integer_ Specefies the primary group of a user by the gid number or the group name. The group will be created if it doesn't exist.
+- `gid`: _String, Integer_ Specifies the primary group of a user by the gid number or the group name. The group will be created if it doesn't exist.
 - `primary_group`: _String_ To be used in combination with the `gid` field when the `gid` is an integer. Specifying the group name prevents errors where the user is created before their primary group.
 
 ## Resources Overview

--- a/README.md
+++ b/README.md
@@ -163,8 +163,9 @@ Other potential fields (optional):
 - `action`: _String_ Supported actions are one's supported by the [user](https://docs.chef.io/resource_user.html#actions) resource. If not specified, the default action is `create`.
 - `ssh_private_key`: _String_ manages user's private key generally ~/.ssh/id_*
 - `ssh_public_key`: _String_ manages user's public key generally ~/.ssh/id_*.pub
-- `authorized_keys_file`:_String_ a nonstandard location for the authorized_keys file
-
+- `authorized_keys_file`: _String_ a nonstandard location for the authorized_keys file
+- `gid`: _String, Integer_ Specefies the primary group of a user by the gid number or the group name. The group will be created if it doesn't exist.
+- `primary_group`: _String_ To be used in combination with the `gid` field when it is an integer. Specifying the group name prevents errors when the user is created before its primary group.
 ## Resources Overview
 
 ### users_manage

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ Other potential fields (optional):
 
 - `home`: _String_ User's home directory. If not assigned, will be set based on platform and username.
 - `manage_home`: _True, False_ Creates/removes the home directory. Defaults to false.
+- `homedir_mode`: _String, Integer_ Modifies a user's home directory permissions.
 - `no_user_group`: _True, False_ Specifies if the user needs to get a group with the name of the users. Defaults to false.
 - `action`: _String_ Supported actions are one's supported by the [user](https://docs.chef.io/resource_user.html#actions) resource. If not specified, the default action is `create`.
 - `ssh_private_key`: _String_ manages user's private key generally ~/.ssh/id_*
 - `ssh_public_key`: _String_ manages user's public key generally ~/.ssh/id_*.pub
 - `authorized_keys_file`: _String_ a nonstandard location for the authorized_keys file
 - `gid`: _String, Integer_ Specefies the primary group of a user by the gid number or the group name. The group will be created if it doesn't exist.
-- `primary_group`: _String_ To be used in combination with the `gid` field when the `gid` is an integer. Specifying the group name prevents errors when the user is created before their primary group.
+- `primary_group`: _String_ To be used in combination with the `gid` field when the `gid` is an integer. Specifying the group name prevents errors where the user is created before their primary group.
 
 ## Resources Overview
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Other potential fields (optional):
 - `ssh_public_key`: _String_ manages user's public key generally ~/.ssh/id_*.pub
 - `authorized_keys_file`: _String_ a nonstandard location for the authorized_keys file
 - `gid`: _String, Integer_ Specefies the primary group of a user by the gid number or the group name. The group will be created if it doesn't exist.
-- `primary_group`: _String_ To be used in combination with the `gid` field when it is an integer. Specifying the group name prevents errors when the user is created before its primary group.
+- `primary_group`: _String_ To be used in combination with the `gid` field when the `gid` is an integer. Specifying the group name prevents errors when the user is created before their primary group.
 ## Resources Overview
 
 ### users_manage

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -73,5 +73,29 @@ module Users
     def pubkey_type(pubkey)
       %w(ed25519 ecdsa dss rsa dsa).filter { |kt| pubkey.split.first.include?(kt) }.first || 'rsa'
     end
+
+    def primary_group(user)
+      if user[:gid]
+        if user[:gid].is_a?(Numeric)
+          user[:primary_group] || user[:id] || user[:username]
+        else
+          user[:gid]
+        end
+      else
+        user[:id] || user[:username]
+      end
+    end
+
+    def primary_gid(user)
+      if user[:gid]
+        if user[:gid].is_a?(Numeric)
+          user[:primary_group] || user[:gid].to_i
+        else
+          user[:gid]
+        end
+      else
+        user[:id] || user[:username]
+      end
+    end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -88,7 +88,7 @@ module Users
       user[:gid] && !username_is_primary?(user) && !primary_gid(user).is_a?(Numeric)
     end
 
-    # Returns a bool, deciding wether a users primary group is its username group based on their user hash
+    # Returns a bool, deciding whether a users primary group is its username group based on their user hash
     #
     # @return [Bool]
     def username_is_primary?(user)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -94,8 +94,8 @@ module Users
     def username_is_primary?(user)
       if user[:gid]
         user[:gid].is_a?(Numeric) && user[:primary_group].nil? && creates_user_group?(user)
-      elsif creates_user_group?(user)
-        true
+      else
+        creates_user_group?(user)
       end
     end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -74,15 +74,55 @@ module Users
       %w(ed25519 ecdsa dss rsa dsa).filter { |kt| pubkey.split.first.include?(kt) }.first || 'rsa'
     end
 
-    def primary_gid(user)
+    # Returns a bool, deciding wether a username group must be created for a user
+    #
+    # @return [Bool]
+    def creates_user_group?(user)
+      !(platform_family?('suse', 'mac_os_x') || user[:no_user_group])
+    end
+
+    # Returns a bool, deciding wether a custom primary group must be created for a user
+    #
+    # @return [Bool]
+    def creates_primary_group?(user)
+      user[:gid] && !username_is_primary?(user) && !primary_gid(user).is_a?(Numeric)
+    end
+
+    # Returns a bool, deciding wether a users primary group is its username group based on their user hash
+    #
+    # @return [Bool]
+    def username_is_primary?(user)
       if user[:gid]
-        if user[:gid].is_a?(Numeric)
-          user[:primary_group] || user[:gid].to_i
-        else
-          user[:gid]
-        end
+        user[:gid].is_a?(Numeric) && user[:primary_group].nil? && creates_user_group?(user)
+      elsif creates_user_group?(user)
+        true
+      end
+    end
+
+    # Returns the name of a users primary group or an integer gid if a string isnt provided
+    # If a user hash contains an integer gid it defaults to the username group, assigning that gid.
+    # If a primary group is also passed than that group will be assigned the gid instead.
+    #
+    # @return [String, Integer]
+    def primary_gid(user)
+      if user[:gid].is_a?(Numeric)
+        user[:primary_group] || user[:gid].to_i
       else
-        user[:id] || user[:username]
+        user[:gid]
+      end
+    end
+
+    # Returns the default user group based on os. On linux this group is the username group
+    #
+    # @return [String]
+    def get_default_group(user)
+      case node['platform_family']
+      when 'suse'
+        'users'
+      when 'mac_os_x'
+        'staff'
+      else
+        user[:username] || user[:id]
       end
     end
   end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -74,18 +74,6 @@ module Users
       %w(ed25519 ecdsa dss rsa dsa).filter { |kt| pubkey.split.first.include?(kt) }.first || 'rsa'
     end
 
-    def primary_group(user)
-      if user[:gid]
-        if user[:gid].is_a?(Numeric)
-          user[:primary_group] || user[:id] || user[:username]
-        else
-          user[:gid]
-        end
-      else
-        user[:id] || user[:username]
-      end
-    end
-
     def primary_gid(user)
       if user[:gid]
         if user[:gid].is_a?(Numeric)

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -70,7 +70,7 @@ action :create do
     # See the -g option limitations in man 8 useradd for an explanation.
     # This section should correct that without breaking functionality.
 
-    # This creats a custom primary group if defined using the 'gid' and 'primary_group' keys
+    # This creates a custom primary group if defined using the 'gid' and 'primary_group' keys
     group primary_gid(user) do
       if platform_family?('mac_os_x')
         gid user[:gid].to_i unless gid_used?(user[:gid].to_i) || new_resource.group_name == username

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -73,13 +73,13 @@ action :create do
     # The user block will fail if the group does not yet exist.
     # See the -g option limitations in man 8 useradd for an explanation.
     # This should correct that without breaking functionality.
-    group username do
+    group primary_group(user) do
       if platform_family?('mac_os_x')
         gid user[:gid].to_i unless gid_used?(user[:gid].to_i) || new_resource.group_name == username
       else
         gid user[:gid].to_i
       end if user[:gid] && user[:gid].is_a?(Numeric)
-      only_if { user[:gid] && user[:gid].is_a?(Numeric) && username_group || user[:groups].include?(username) }
+      only_if { (user[:gid] || user[:groups].include?(username)) && (username_group || user[:gid].is_a?(String) || user[:primary_group]) }
       append true
     end
 
@@ -87,7 +87,7 @@ action :create do
     # Do NOT try to manage null home directories.
     user username do
       uid user[:uid].to_i unless platform_family?('mac_os_x') || !user[:uid]
-      gid user[:gid] || username if user[:gid] || user[:groups].include?(username)
+      gid primary_gid(user) if user[:gid] || user[:groups].include?(username)
       shell shell_is_valid?(user[:shell]) ? user[:shell] : '/bin/sh'
       comment user[:comment]
       password user[:password] if user[:password]
@@ -98,13 +98,17 @@ action :create do
       action :create
     end
 
+    group username do
+      members username
+      append true
+    end if username_group && primary_group(user) != username
+
     if manage_home_files?(home_dir, username)
       Chef::Log.debug("Managing home files for #{username}")
-
       directory "#{home_dir}/.ssh" do
         recursive true
         owner user[:uid] ? user[:uid].to_i : username
-        group user[:gid].to_i if user[:gid]
+        group primary_gid(user)
         mode '0700'
         not_if { user[:ssh_keys].nil? && user[:ssh_private_key].nil? && user[:ssh_public_key].nil? }
       end
@@ -127,7 +131,7 @@ action :create do
         source 'authorized_keys.erb'
         cookbook new_resource.cookbook
         owner user[:uid] ? user[:uid].to_i : username
-        group user[:gid].to_i if user[:gid]
+        group primary_gid(user)
         mode '0600'
         sensitive true
         # ssh_keys should be a combination of user['ssh_keys'] and any keys
@@ -142,7 +146,7 @@ action :create do
           source 'public_key.pub.erb'
           cookbook new_resource.cookbook
           owner user[:uid] ? user[:uid].to_i : username
-          group user[:gid].to_i if user[:gid]
+          group primary_gid(user)
           mode '0400'
           variables public_key: user[:ssh_public_key]
         end
@@ -154,7 +158,7 @@ action :create do
           source 'private_key.erb'
           cookbook new_resource.cookbook
           owner user[:uid] ? user[:uid].to_i : username
-          group user[:gid].to_i if user[:gid]
+          group primary_gid(user)
           mode '0400'
           variables private_key: user[:ssh_private_key]
         end

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -66,28 +66,38 @@ action :create do
     # check whether home dir is null
     manage_home = !(home_dir == '/dev/null')
 
-    # Check if we need to create a user group for the user
-    # True by default
-    username_group = user[:no_user_group] ? false : true
-
-    # The user block will fail if the group does not yet exist.
+    # The user block will fail if its primary group doesn't exist.
     # See the -g option limitations in man 8 useradd for an explanation.
-    # This should correct that without breaking functionality.
-    group primary_gid(user).is_a?(Numeric) ? username : primary_gid(user) do
+    # This section should correct that without breaking functionality.
+
+    # This creats a custom primary group if defined using the 'gid' and 'primary_group' keys
+    group primary_gid(user) do
       if platform_family?('mac_os_x')
         gid user[:gid].to_i unless gid_used?(user[:gid].to_i) || new_resource.group_name == username
       else
         gid user[:gid].to_i
-      end if user[:gid] && user[:gid].is_a?(Numeric)
-      only_if { (user[:gid] || user[:groups].include?(username)) && (username_group || user[:gid].is_a?(String) || user[:primary_group]) }
+      end if user[:gid].is_a?(Numeric)
       append true
+    end if creates_primary_group?(user)
+
+    # This creates a username group, it needs to be notified by another block so that it doesnt attempt to add a user
+    # that doesnt exist
+    group username do
+      if platform_family?('mac_os_x')
+        gid user[:gid].to_i unless gid_used?(user[:gid].to_i) || new_resource.group_name == username
+      else
+        gid user[:gid].to_i
+      end if user[:gid] && username_is_primary?(user)
+      members username unless username_is_primary?(user)
+      append true
+      action :nothing
     end
 
     # Create user object.
     # Do NOT try to manage null home directories.
     user username do
       uid user[:uid].to_i unless platform_family?('mac_os_x') || !user[:uid]
-      gid primary_gid(user) if user[:gid] || user[:groups].include?(username)
+      gid user[:gid] ? primary_gid(user) : get_default_group(user)
       shell shell_is_valid?(user[:shell]) ? user[:shell] : '/bin/sh'
       comment user[:comment]
       password user[:password] if user[:password]
@@ -96,20 +106,23 @@ action :create do
       manage_home manage_home
       home home_dir unless platform_family?('mac_os_x')
       action :create
+      if username_is_primary?(user)
+        notifies :create, "group[#{username}]", :before
+      elsif creates_user_group?(user)
+        notifies :create, "group[#{username}]", :immediately
+      end
     end
-
-    # The username group may not be the primary group, but still need to exist.
-    group username do
-      members username
-      append true
-    end if username_group && (primary_gid(user).is_a?(Numeric) || primary_gid(user) != username)
 
     if manage_home_files?(home_dir, username)
       Chef::Log.debug("Managing home files for #{username}")
+      directory home_dir do
+        mode user[:homedir_mode]
+      end if user[:homedir_mode]
+
       directory "#{home_dir}/.ssh" do
         recursive true
         owner user[:uid] ? user[:uid].to_i : username
-        group platform_family?('suse') ? 'users' : primary_gid(user)
+        group user[:gid] ? primary_gid(user) : get_default_group(user)
         mode '0700'
         not_if { user[:ssh_keys].nil? && user[:ssh_private_key].nil? && user[:ssh_public_key].nil? }
       end
@@ -132,7 +145,7 @@ action :create do
         source 'authorized_keys.erb'
         cookbook new_resource.cookbook
         owner user[:uid] ? user[:uid].to_i : username
-        group platform_family?('suse') ? 'users' : primary_gid(user)
+        group user[:gid] ? primary_gid(user) : get_default_group(user)
         mode '0600'
         sensitive true
         # ssh_keys should be a combination of user['ssh_keys'] and any keys
@@ -147,7 +160,7 @@ action :create do
           source 'public_key.pub.erb'
           cookbook new_resource.cookbook
           owner user[:uid] ? user[:uid].to_i : username
-          group platform_family?('suse') ? 'users' : primary_gid(user)
+          group user[:gid] ? primary_gid(user) : get_default_group(user)
           mode '0400'
           variables public_key: user[:ssh_public_key]
         end
@@ -159,7 +172,7 @@ action :create do
           source 'private_key.erb'
           cookbook new_resource.cookbook
           owner user[:uid] ? user[:uid].to_i : username
-          group platform_family?('suse') ? 'users' : primary_gid(user)
+          group user[:gid] ? primary_gid(user) : get_default_group(user)
           mode '0400'
           variables private_key: user[:ssh_private_key]
         end

--- a/test/fixtures/cookbooks/users_test/attributes/default.rb
+++ b/test/fixtures/cookbooks/users_test/attributes/default.rb
@@ -48,4 +48,16 @@ default['users_test']['users'] = [{
 {
   'username': 'explicituser',
   'groups': ['explicituser'],
+},
+{
+  'username': 'joins_spawned_group',
+  'gid': 'string_gid',
+  'no_user_group': true,
+  'groups': ['user_before_group'],
+},
+{
+  'username': 'primary_integer_gid',
+  'groups': %w(spawns_next_group user_before_group),
+  'primary_group': 'user_before_group',
+  'gid': 6000,
 }]

--- a/test/fixtures/cookbooks/users_test/attributes/default.rb
+++ b/test/fixtures/cookbooks/users_test/attributes/default.rb
@@ -60,4 +60,10 @@ default['users_test']['users'] = [{
   'groups': %w(spawns_next_group user_before_group),
   'primary_group': 'user_before_group',
   'gid': 6000,
+},
+{
+  'username': 'nonstandard_homedir_perms',
+  'homedir_mode': '02755',
+  'ssh_keys': ['ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC6aZDF+x28xIlZSgyfyh3IAkencLp1VCU7JXBhJcXNy cheftestuser@laptop'],
+  'groups': ['nonstandard_homedir_perms'],
 }]

--- a/test/fixtures/cookbooks/users_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/users_test/recipes/default.rb
@@ -31,3 +31,12 @@ end
 users_manage 'explicituser' do
   users node['users_test']['users']
 end
+
+users_manage 'spawns_next_group' do
+  users node['users_test']['users']
+end
+
+users_manage 'user_before_group' do
+  group_id 6000
+  users node['users_test']['users']
+end

--- a/test/fixtures/cookbooks/users_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/users_test/recipes/default.rb
@@ -40,3 +40,7 @@ users_manage 'user_before_group' do
   group_id 6000
   users node['users_test']['users']
 end
+
+users_manage 'nonstandard_homedir_perms' do
+  users node['users_test']['users']
+end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -79,12 +79,14 @@ describe file('/home/user_with_nfs_home_second/.ssh/id_ecdsa') do
   it { should exist }
   its('content') { should include("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS\n1zaGEyLW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQQns8Ec3poQBm6r7zv/UZojvXjrUZVB\n59R4LzOBw8cS/2xSQrVH8qm2X8kB1y6nuyydK0bbQF1pnES1P+uvG6e9AAAAsD2Nf449jX\n+OAAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCezwRzemhAGbqvv\nO/9RmiO9eOtRlUHn1HgvM4HDxxL/bFJCtUfyqbZfyQHXLqe7LJ0rRttAXWmcRLU/668bp7\n0AAAAgJp/B6o2OADM0+NlkgH1dFcOLK64jhr3ScbWK4iyRdOcAAAAVZm11bGxlckBzYnBs\ndGMxbWxsdmRsAQID\n-----END OPENSSH PRIVATE KEY-----\n") }
   its('owner') { should eq 'user_with_nfs_home_second' }
+  its('group') { should eq 'user_with_nfs_home_second' }
 end unless os_family == 'darwin' # InSpec runs as non-root and can't see these files
 
 describe file('/home/user_with_nfs_home_second/.ssh/id_ecdsa.pub') do
   it { should exist }
   its('content') { should include('ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCezwRzemhAGbqvvO/9RmiO9eOtRlUHn1HgvM4HDxxL/bFJCtUfyqbZfyQHXLqe7LJ0rRttAXWmcRLU/668bp70=') }
   its('owner') { should eq 'user_with_nfs_home_second' }
+  its('group') { should eq 'user_with_nfs_home_second' }
 end unless os_family == 'darwin' # InSpec runs as non-root and can't see these files
 
 describe user('user_with_local_home') do
@@ -113,6 +115,7 @@ end
 describe directory('/home/user_with_local_home') do
   it { should exist }
   its('owner') { should eq 'user_with_local_home' }
+  its('group') { should eq 'user_with_local_home' }
 end unless os_family == 'darwin' # InSpec runs as non-root and can't see these files
 
 describe file('/home/user_with_local_home/.ssh/id_rsa') do
@@ -136,28 +139,33 @@ end
 describe directory('/home/user_with_username_instead_of_id') do
   it { should exist }
   its('owner') { should eq 'user_with_username_instead_of_id' }
+  its('group') { should eq 'user_with_username_instead_of_id' }
 end unless os_family == 'darwin'
 
 describe directory('/home/user_with_username_instead_of_id/.ssh') do
   it { should exist }
   its('owner') { should eq 'user_with_username_instead_of_id' }
+  its('group') { should eq 'user_with_username_instead_of_id' }
 end unless os_family == 'darwin'
 
 describe file('/home/user_with_username_instead_of_id/.ssh/authorized_keys') do
   it { should exist }
   its('owner') { should eq 'user_with_username_instead_of_id' }
+  its('group') { should eq 'user_with_username_instead_of_id' }
   its('content') { should include('ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC6aZDF+x28xIlZSgyfyh3IAkencLp1VCU7JXBhJcXNy cheftestuser@laptop') }
 end unless os_family == 'darwin'
 
 describe file('/home/user_with_username_instead_of_id/.ssh/id_ecdsa') do
   it { should exist }
   its('owner') { should eq 'user_with_username_instead_of_id' }
+  its('group') { should eq 'user_with_username_instead_of_id' }
   its('content') { should include("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\nQyNTUxOQAAACAummQxfsdvMSJWUoMn8odyAJHp3C6dVQlOyVwYSXFzcgAAAJjzcJxA83Cc\nQAAAAAtzc2gtZWQyNTUxOQAAACAummQxfsdvMSJWUoMn8odyAJHp3C6dVQlOyVwYSXFzcg\nAAAEC7TGfA0MU0mh0V39qw5RSThUo0idTtU2vCe9bJrHmyFS6aZDF+x28xIlZSgyfyh3IA\nkencLp1VCU7JXBhJcXNyAAAAFWZtdWxsZXJAc2JwbHRjMW1sbHZkbA==\n-----END OPENSSH PRIVATE KEY-----\n") }
 end unless os_family == 'darwin'
 
 describe file('/home/user_with_username_instead_of_id/.ssh/id_ecdsa.pub') do
   it { should exist }
   its('owner') { should eq 'user_with_username_instead_of_id' }
+  its('group') { should eq 'user_with_username_instead_of_id' }
   its('content') { should include('ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCezwRzemhAGbqvvO/9RmiO9eOtRlUHn1HgvM4HDxxL/bFJCtUfyqbZfyQHXLqe7LJ0rRttAXWmcRLU/668bp70=') }
 end unless os_family == 'darwin'
 
@@ -213,5 +221,29 @@ describe file('/home/databag_test_user_keys_from_url/.ssh/authorized_keys') do
   ssh_keys.each do |key|
     its('content') { should include(key) }
     its('owner') { should eq 'databag_test_user_keys_from_url' }
+    its('group') { should eq 'databag_test_user_keys_from_url' }
   end
 end unless os_family == 'darwin' # InSpec runs as non-root and can't see these files
+
+describe user('joins_spawned_group') do
+  it { should exist }
+  case os_family
+  when 'darwin'
+    %w(group_b group_c).each do |g|
+      its('groups') { should include g }
+    end else
+    its('groups') { should eq %w(string_gid user_before_group) }
+  end
+end
+
+describe user('primary_integer_gid') do
+  it { should exist }
+  case os_family
+  when 'darwin'
+    %w(group_a group_b in_group_a_b).each do |g|
+      its('groups') { should include g }
+    end
+  else
+    its('groups') { should eq %w(user_before_group spawns_next_group primary_integer_gid) }
+  end
+end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -79,14 +79,24 @@ describe file('/home/user_with_nfs_home_second/.ssh/id_ecdsa') do
   it { should exist }
   its('content') { should include("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS\n1zaGEyLW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQQns8Ec3poQBm6r7zv/UZojvXjrUZVB\n59R4LzOBw8cS/2xSQrVH8qm2X8kB1y6nuyydK0bbQF1pnES1P+uvG6e9AAAAsD2Nf449jX\n+OAAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCezwRzemhAGbqvv\nO/9RmiO9eOtRlUHn1HgvM4HDxxL/bFJCtUfyqbZfyQHXLqe7LJ0rRttAXWmcRLU/668bp7\n0AAAAgJp/B6o2OADM0+NlkgH1dFcOLK64jhr3ScbWK4iyRdOcAAAAVZm11bGxlckBzYnBs\ndGMxbWxsdmRsAQID\n-----END OPENSSH PRIVATE KEY-----\n") }
   its('owner') { should eq 'user_with_nfs_home_second' }
-  its('group') { should eq 'user_with_nfs_home_second' }
+  case os_family
+  when 'suse'
+    its('group') { should eq 'users' }
+  else
+    its('group') { should eq 'user_with_nfs_home_second' }
+  end
 end unless os_family == 'darwin' # InSpec runs as non-root and can't see these files
 
 describe file('/home/user_with_nfs_home_second/.ssh/id_ecdsa.pub') do
   it { should exist }
   its('content') { should include('ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCezwRzemhAGbqvvO/9RmiO9eOtRlUHn1HgvM4HDxxL/bFJCtUfyqbZfyQHXLqe7LJ0rRttAXWmcRLU/668bp70=') }
   its('owner') { should eq 'user_with_nfs_home_second' }
-  its('group') { should eq 'user_with_nfs_home_second' }
+  case os_family
+  when 'suse'
+    its('group') { should eq 'users' }
+  else
+    its('group') { should eq 'user_with_nfs_home_second' }
+  end
 end unless os_family == 'darwin' # InSpec runs as non-root and can't see these files
 
 describe user('user_with_local_home') do
@@ -115,7 +125,12 @@ end
 describe directory('/home/user_with_local_home') do
   it { should exist }
   its('owner') { should eq 'user_with_local_home' }
-  its('group') { should eq 'user_with_local_home' }
+  case os_family
+  when 'suse'
+    its('group') { should eq 'users' }
+  else
+    its('group') { should eq 'user_with_local_home' }
+  end
 end unless os_family == 'darwin' # InSpec runs as non-root and can't see these files
 
 describe file('/home/user_with_local_home/.ssh/id_rsa') do
@@ -139,33 +154,58 @@ end
 describe directory('/home/user_with_username_instead_of_id') do
   it { should exist }
   its('owner') { should eq 'user_with_username_instead_of_id' }
-  its('group') { should eq 'user_with_username_instead_of_id' }
+  case os_family
+  when 'suse'
+    its('group') { should eq 'users' }
+  else
+    its('group') { should eq 'user_with_username_instead_of_id' }
+  end
 end unless os_family == 'darwin'
 
 describe directory('/home/user_with_username_instead_of_id/.ssh') do
   it { should exist }
   its('owner') { should eq 'user_with_username_instead_of_id' }
-  its('group') { should eq 'user_with_username_instead_of_id' }
+  case os_family
+  when 'suse'
+    its('group') { should eq 'users' }
+  else
+    its('group') { should eq 'user_with_username_instead_of_id' }
+  end
 end unless os_family == 'darwin'
 
 describe file('/home/user_with_username_instead_of_id/.ssh/authorized_keys') do
   it { should exist }
   its('owner') { should eq 'user_with_username_instead_of_id' }
-  its('group') { should eq 'user_with_username_instead_of_id' }
+  case os_family
+  when 'suse'
+    its('group') { should eq 'users' }
+  else
+    its('group') { should eq 'user_with_username_instead_of_id' }
+  end
   its('content') { should include('ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC6aZDF+x28xIlZSgyfyh3IAkencLp1VCU7JXBhJcXNy cheftestuser@laptop') }
 end unless os_family == 'darwin'
 
 describe file('/home/user_with_username_instead_of_id/.ssh/id_ecdsa') do
   it { should exist }
   its('owner') { should eq 'user_with_username_instead_of_id' }
-  its('group') { should eq 'user_with_username_instead_of_id' }
+  case os_family
+  when 'suse'
+    its('group') { should eq 'users' }
+  else
+    its('group') { should eq 'user_with_username_instead_of_id' }
+  end
   its('content') { should include("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\nQyNTUxOQAAACAummQxfsdvMSJWUoMn8odyAJHp3C6dVQlOyVwYSXFzcgAAAJjzcJxA83Cc\nQAAAAAtzc2gtZWQyNTUxOQAAACAummQxfsdvMSJWUoMn8odyAJHp3C6dVQlOyVwYSXFzcg\nAAAEC7TGfA0MU0mh0V39qw5RSThUo0idTtU2vCe9bJrHmyFS6aZDF+x28xIlZSgyfyh3IA\nkencLp1VCU7JXBhJcXNyAAAAFWZtdWxsZXJAc2JwbHRjMW1sbHZkbA==\n-----END OPENSSH PRIVATE KEY-----\n") }
 end unless os_family == 'darwin'
 
 describe file('/home/user_with_username_instead_of_id/.ssh/id_ecdsa.pub') do
   it { should exist }
   its('owner') { should eq 'user_with_username_instead_of_id' }
-  its('group') { should eq 'user_with_username_instead_of_id' }
+  case os_family
+  when 'suse'
+    its('group') { should eq 'users' }
+  else
+    its('group') { should eq 'user_with_username_instead_of_id' }
+  end
   its('content') { should include('ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCezwRzemhAGbqvvO/9RmiO9eOtRlUHn1HgvM4HDxxL/bFJCtUfyqbZfyQHXLqe7LJ0rRttAXWmcRLU/668bp70=') }
 end unless os_family == 'darwin'
 
@@ -221,7 +261,12 @@ describe file('/home/databag_test_user_keys_from_url/.ssh/authorized_keys') do
   ssh_keys.each do |key|
     its('content') { should include(key) }
     its('owner') { should eq 'databag_test_user_keys_from_url' }
-    its('group') { should eq 'databag_test_user_keys_from_url' }
+    case os_family
+    when 'suse'
+      its('group') { should eq 'users' }
+    else
+      its('group') { should eq 'databag_test_user_keys_from_url' }
+    end
   end
 end unless os_family == 'darwin' # InSpec runs as non-root and can't see these files
 


### PR DESCRIPTION
# Description

Instead of root, the users primary group will be the group owner of their generated `.ssh/*` files.
Allows a user to specify their home directory's file permissions.

## Issues Resolved

None

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
