### PR TITLE
Use the Chef Infra provisioner rather than Zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the users cookbook.
 
 ## Unreleased
 
+- CI: Use the chef-infra provisioner instead of chef-zero
+
 ## 7.1.0 - *2021-07-28*
 
 - Give group ownership of each users .ssh/* files to that users primary group

--- a/kitchen.exec.yml
+++ b/kitchen.exec.yml
@@ -1,13 +1,6 @@
 ---
-driver:
-  name: exec
-
-transport:
-  name: exec
-
-provisioner:
-  name: chef_zero
-  deprecations_as_errors: true
+driver: { name: exec }
+transport: { name: exec }
 
 platforms:
   - name: macos-latest

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,7 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_zero
+  name: chef_infra
   deprecations_as_errors: true
   enforce_idempotency: true
   multiple_converge: 2


### PR DESCRIPTION
# Description

chef-zero is now chef-infra

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
