### PR TITLE
Fix macos && suse gid issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of the users cookbook.
 
 ## Unreleased
 
+- Patch bug causing the cookbook to fail on suse and macos.
+- Update README to lessen confusion.
+- This may still be a breaking change for some users, but is hopefully no longer a bug.
+
 ## 7.1.1 - *2021-08-02*
 
 - CI: Use the chef-infra provisioner instead of chef-zero

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Other potential fields (optional):
 - `ssh_private_key`: _String_ manages user's private key generally ~/.ssh/id_*
 - `ssh_public_key`: _String_ manages user's public key generally ~/.ssh/id_*.pub
 - `authorized_keys_file`: _String_ a nonstandard location for the authorized_keys file
-- `gid`: _String, Integer_ Specifies the primary group of a user by the gid number or the group name. The group will be created if it doesn't exist.
+- `gid`: _String, Integer_ Specifies the primary group of a user by the gid number or the group name. If `gid` is an integer and no `primary_group` is specefied than the gid will be assigned to the username group, if applicable. The group will be created if it doesn't exist.
 - `primary_group`: _String_ To be used in combination with the `gid` field when the `gid` is an integer. Specifying the group name prevents errors where the user is created before their primary group.
 
 ## Resources Overview

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -97,7 +97,11 @@ action :create do
     # Do NOT try to manage null home directories.
     user username do
       uid user[:uid].to_i unless platform_family?('mac_os_x') || !user[:uid]
-      gid user[:gid] ? primary_gid(user) : get_default_group(user)
+      if user[:gid] && !primary_gid(user).is_a?(Numeric)
+        gid primary_gid(user)
+      else
+        gid get_default_group(user)
+      end
       shell shell_is_valid?(user[:shell]) ? user[:shell] : '/bin/sh'
       comment user[:comment]
       password user[:password] if user[:password]
@@ -122,7 +126,11 @@ action :create do
       directory "#{home_dir}/.ssh" do
         recursive true
         owner user[:uid] ? user[:uid].to_i : username
-        group user[:gid] ? primary_gid(user) : get_default_group(user)
+        if user[:gid] && !primary_gid(user).is_a?(Numeric)
+          group primary_gid(user)
+        else
+          group get_default_group(user)
+        end
         mode '0700'
         not_if { user[:ssh_keys].nil? && user[:ssh_private_key].nil? && user[:ssh_public_key].nil? }
       end
@@ -145,7 +153,11 @@ action :create do
         source 'authorized_keys.erb'
         cookbook new_resource.cookbook
         owner user[:uid] ? user[:uid].to_i : username
-        group user[:gid] ? primary_gid(user) : get_default_group(user)
+        if user[:gid] && !primary_gid(user).is_a?(Numeric)
+          group primary_gid(user)
+        else
+          group get_default_group(user)
+        end
         mode '0600'
         sensitive true
         # ssh_keys should be a combination of user['ssh_keys'] and any keys
@@ -160,7 +172,11 @@ action :create do
           source 'public_key.pub.erb'
           cookbook new_resource.cookbook
           owner user[:uid] ? user[:uid].to_i : username
-          group user[:gid] ? primary_gid(user) : get_default_group(user)
+          if user[:gid] && !primary_gid(user).is_a?(Numeric)
+            group primary_gid(user)
+          else
+            group get_default_group(user)
+          end
           mode '0400'
           variables public_key: user[:ssh_public_key]
         end
@@ -172,7 +188,11 @@ action :create do
           source 'private_key.erb'
           cookbook new_resource.cookbook
           owner user[:uid] ? user[:uid].to_i : username
-          group user[:gid] ? primary_gid(user) : get_default_group(user)
+          if user[:gid] && !primary_gid(user).is_a?(Numeric)
+            group primary_gid(user)
+          else
+            group get_default_group(user)
+          end
           mode '0400'
           variables private_key: user[:ssh_private_key]
         end

--- a/test/fixtures/cookbooks/users_test/attributes/default.rb
+++ b/test/fixtures/cookbooks/users_test/attributes/default.rb
@@ -16,6 +16,7 @@ default['users_test']['users'] = [{
   'uid': 5000,
   'gid': 4000,
   'groups': ['nfsgroup'],
+  'primary_group': 'nfsgroup',
   'shell': '/bin/bash',
   'home': '/dev/null',
   'no_user_group': true,

--- a/test/fixtures/data_bags/test_home_dir/databag_username_gid.json
+++ b/test/fixtures/data_bags/test_home_dir/databag_username_gid.json
@@ -1,0 +1,5 @@
+{
+  "username": "username_gid",
+  "groups": ["testgroup"],
+  "gid": 7000
+}

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -385,3 +385,18 @@ describe directory('/home/nonstandard_homedir_perms/.ssh') do
   end
   its('mode') { should cmp '0700' }
 end unless os_family == 'darwin'
+
+describe user('username_gid') do
+  it { should exist }
+  case os_family
+  when 'suse'
+    its('groups') { should cmp %w(users testgroup) }
+  when 'darwin'
+    %w(staff testgroup).each do |g|
+      its('groups') { should include g }
+    end
+  else
+    its('groups') { should cmp %w(username_gid testgroup) }
+    its('gid') { should eq 7000 }
+  end
+end


### PR DESCRIPTION
# Description

Patches a bug I introduced in 7.1
This is a breaking change for the following use case, where a non-username primary group is given to a user by an integer `gid` alone. 

```ruby
u = [{
  'id': 'X'
  'groups': ['A'],
  'gid': 7000,
  'no_user_group': true
}]

users_manage 'A' do
  users u
  group_id 7000
end
```

This case is bad practice, if a second group is introduces it can break, and the gid field is agnostic of its primary group.

```ruby
u = [{
  'id': 'X'
  'groups': ['A', 'B'],
  'gid': 7000,
  'no_user_group': true
}]

users_manage 'A' do
  users u
end

users_manage 'B' do
  users u
  group_id 7000
end
```

The fix for this issue was also included in 7.1. It is to include the `primary_group` key in the user hash, which defines the primary group belonging to an integer gid. This is not needed when the `gid` is a string or meant to be associated with the username group. The proper way to handle this case is as follows. 

```ruby
u = [{
  'id': 'X'
  'groups': ['A', 'B'],
  'gid': 7000,
  'primary_group': 'B',
  'no_user_group': true
}]

users_manage 'A' do
  users u
end

users_manage 'B' do
  users u
  group_id 7000
end
```

This will ensure that group 'B' is created with the proper gid and that the user 'X' can have it as its primary group.

## Issues Resolved

https://github.com/sous-chefs/users/issues/459

## Check List

- [X] All tests pass. See TESTING.md for details.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
