### PR TITLE
Add system option to user and group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of the users cookbook.
 
 ## Unreleased
 
+- add system option to resource
+- add system option to user json
+- add corresponding integration tests
+
 ## 8.0.0 - *2021-08-05*
 
 - Patch bug causing the cookbook to fail on suse and macos.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Other potential fields (optional):
 - `authorized_keys_file`: _String_ a nonstandard location for the authorized_keys file
 - `gid`: _String, Integer_ Specifies the primary group of a user by the gid number or the group name. If `gid` is an integer and no `primary_group` is specefied than the gid will be assigned to the username group, if applicable. The group will be created if it doesn't exist.
 - `primary_group`: _String_ To be used in combination with the `gid` field when the `gid` is an integer. Specifying the group name prevents errors where the user is created before their primary group.
+- `system`: _True, False_ Specefies if a user is a system account. See the `-r` option of `useradd`.
 
 ## Resources Overview
 
@@ -217,6 +218,7 @@ end
 - `group_id` _Integer_ numeric id of the group to create, default is to allow the OS to pick next
 - `cookbook` _String_ name of the cookbook that the authorized_keys template should be found in
 - `manage_nfs_home_dirs` _Boolean_ whether to manage nfs home directories.
+- `system` _True, False_ Specefies if a group is a system group. See the `-r` option of `groupadd`.
 
 ## Recipe Overview
 

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -23,7 +23,7 @@ property :group_id, Integer, description: 'numeric id of the group to create, de
 property :users, Array, description: 'Array of Hashes that contains all the users that you want to create with the users cookbook.', default: []
 property :cookbook, String, description: 'name of the cookbook that the authorized_keys template should be found in.', default: 'users'
 property :manage_nfs_home_dirs, [true, false], description: 'specifies if home_dirs should be managed when they are located on a NFS share.', default: true
-
+property :system, [true, false], description: 'specefies if the group should be a system group. See the -r option of groupadd', default: false
 # Deprecated properties
 property :data_bag, String, deprecated: 'The data_bag property has been deprecated, please see upgrading.md for more information. The property will be removed in the next major release.'
 
@@ -45,6 +45,7 @@ action :create do
       gid new_resource.group_id
       not_if "getent group #{new_resource.group_name}"
     end
+    system new_resource.system
   end
 
   # Loop through all the users in the users_hash
@@ -109,6 +110,7 @@ action :create do
       iterations user[:iterations] if user[:iterations]
       manage_home manage_home
       home home_dir unless platform_family?('mac_os_x')
+      system user[:system] unless user[:system].nil?
       action :create
       if username_is_primary?(user)
         notifies :create, "group[#{username}]", :before

--- a/test/fixtures/cookbooks/users_test/attributes/default.rb
+++ b/test/fixtures/cookbooks/users_test/attributes/default.rb
@@ -67,4 +67,9 @@ default['users_test']['users'] = [{
   'homedir_mode': '02755',
   'ssh_keys': ['ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC6aZDF+x28xIlZSgyfyh3IAkencLp1VCU7JXBhJcXNy cheftestuser@laptop'],
   'groups': ['nonstandard_homedir_perms'],
+},
+{
+  'id': 'system_user',
+  'groups': ['system_group'],
+  'system': true,
 }]

--- a/test/fixtures/cookbooks/users_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/users_test/recipes/default.rb
@@ -44,3 +44,8 @@ end
 users_manage 'nonstandard_homedir_perms' do
   users node['users_test']['users']
 end
+
+users_manage 'system_group' do
+  users node['users_test']['users']
+  system true
+end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -400,3 +400,13 @@ describe user('username_gid') do
     its('gid') { should eq 7000 }
   end
 end
+
+describe user('system_user') do
+  it { should exist }
+  its('uid') { should be < 1000 } unless os_family == 'darwin'
+end
+
+describe group('system_group') do
+  it { should exist }
+  its('gid') { should be < 1000 } unless os_family == 'darwin'
+end


### PR DESCRIPTION
# Description

Add an option for the managed users and groups to be created as system

## Issues Resolved

None

## Check List

- [X] All tests pass. See TESTING.md for details.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
